### PR TITLE
Improve AOT profiles triggering configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.aot.ProcessAot
+
 plugins {
 	java
 	id("org.springframework.boot") version "3.0.5"
@@ -16,6 +18,10 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<ProcessAot> {
+    args("--spring.profiles.active=" + (project.properties["aotProfiles"] ?: "default"))
 }
 
 tasks.withType<Test> {

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 	<description>Demo project for Spring profiles with AOT optimizations</description>
 	<properties>
 		<java.version>17</java.version>
+		<aot.profiles>default</aot.profiles>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -44,18 +45,21 @@
 
 	<profiles>
 		<profile>
-			<id>prod</id>
+			<id>native</id>
 			<build>
 				<pluginManagement>
 					<plugins>
 						<plugin>
 							<groupId>org.springframework.boot</groupId>
 							<artifactId>spring-boot-maven-plugin</artifactId>
-							<configuration>
-								<profiles>
-									<profile>prod</profile>
-								</profiles>
-							</configuration>
+							<executions>
+								<execution>
+									<id>process-aot</id>
+									<configuration>
+										<profiles>${aot.profiles}</profiles>
+									</configuration>
+								</execution>
+							</executions>
 						</plugin>
 					</plugins>
 				</pluginManagement>


### PR DESCRIPTION
This commit reviews the existing arrangement to make it more idiomatic. Rather than hard-coding the profile to use, a dedicated AOT-specific property is exposed.

This makes sure that "Spring profiles for AOT" and the regular runtime semantics are separated.